### PR TITLE
Fixed memory candidate: multiplication => addition

### DIFF
--- a/entity_networks/dynamic_memory_cell.py
+++ b/entity_networks/dynamic_memory_cell.py
@@ -62,7 +62,7 @@ class DynamicMemoryCell(tf.contrib.rnn.RNNCell):
         key_V = tf.matmul(key_j, V)
         state_U = tf.matmul(state_j, U) + U_bias
         inputs_W = tf.matmul(inputs, W)
-        return self._activation(state_U * inputs_W * key_V)
+        return self._activation(state_U + inputs_W + key_V)
 
     def __call__(self, inputs, state, scope=None):
         with tf.variable_scope(scope or type(self).__name__, initializer=self._initializer):


### PR DESCRIPTION
Thank you for providing the TensorFlow implementation.
One minor fix.

As per Equation (3) in the original paper, it should be addition:
`h_j^~ <- \phi(U h_j + V w_j + W s_t)`
rather than multiplication:
`h_j^~ <- \phi(U h_j * V w_j * W s_t)`

This can be further verified in their Torch code: 
`local candidate_memories = nn.PReLU(opt.edim)(nn.CAddTable(){U, V, W}):annotate{name = 'prelu'}`